### PR TITLE
fixed storage of chatbox name; updated forge

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -11,7 +11,7 @@ apply plugin: 'net.minecraftforge.gradle.forge'
 //Only edit below this line, the above code adds and enables the necessary things for Forge to be setup.
 
 
-version = "1.12.2-1.3.0"
+version = "1.12.2-1.4.0"
 group= "com.jlgm.chatbox" // http://maven.apache.org/guides/mini/guide-naming-conventions.html
 archivesBaseName = "jlgm_chatbox"
 
@@ -21,7 +21,7 @@ compileJava {
 }
 
 minecraft {
-    version = "1.12.2-14.23.0.2486"
+    version = "1.12.2-14.23.4.2705"
     runDir = "run"
     
     // the mappings can be changed at any time, and must be in the following format.

--- a/src/main/java/com/jlgm/chatbox/tileentity/TileEntityChatBox.java
+++ b/src/main/java/com/jlgm/chatbox/tileentity/TileEntityChatBox.java
@@ -30,7 +30,7 @@ public class TileEntityChatBox extends TileEntity implements IWorldNameable{
 	private boolean powered;
 	
 	public TileEntityChatBox(){
-		this.message = "Hello there!";
+		this.message = "Hello there! - General Kenobi!";
 		this.radius = 10;
 	}
 	
@@ -108,6 +108,7 @@ public class TileEntityChatBox extends TileEntity implements IWorldNameable{
     public NBTTagCompound writeToNBT(NBTTagCompound tagCompound){
 		super.writeToNBT(tagCompound);
 		tagCompound.setString("Message", this.message);
+		tagCompound.setString("CustomName", this.customName);
 		tagCompound.setInteger("Radius", this.radius);
 		return tagCompound;
 	}
@@ -116,6 +117,7 @@ public class TileEntityChatBox extends TileEntity implements IWorldNameable{
 	public void readFromNBT(NBTTagCompound tagCompound){
 		super.readFromNBT(tagCompound);
 		this.message = tagCompound.getString("Message");
+		this.customName = tagCompound.getString("CustomName");
 		this.radius = tagCompound.getInteger("Radius");
 	}
 	


### PR DESCRIPTION
now a map reload doesn't clear the chatbox name, fixing #1 

There seems to be a rendering issue, because the block is just purple-black. I haven't changed anything except these two lines I've added. Do you know the reason? 